### PR TITLE
Use SpaCy word vectors for comparing similarity

### DIFF
--- a/axyn/chatbot/nlploader.py
+++ b/axyn/chatbot/nlploader.py
@@ -8,4 +8,7 @@ logger = logging.getLogger(__name__)
 # This module exists to ensure we only load the model once
 # for use in all modules.
 logger.info('Loading NLP model')
-nlp = spacy.load('en_core_web_sm')
+nlp = spacy.load(
+    'en_core_web_md',
+    disable=['ner', 'textcat']
+)

--- a/axyn/chatbot/response.py
+++ b/axyn/chatbot/response.py
@@ -47,9 +47,9 @@ def get_closest_match(text, options):
         text, len(options)
     )
 
-    #if text in options:
-    #    logger.debug('Options contains an exact match, returning now')
-    #    return text, 1
+    if text in options:
+        logger.debug('Options contain an exact match, returning now')
+        return text, 0
 
     logger.debug('Getting document vectors')
     text_doc = nlp(text)

--- a/axyn/chatbot/response.py
+++ b/axyn/chatbot/response.py
@@ -32,7 +32,6 @@ def process_as_math(text):
         return None
 
 
-
 def get_closest_match(text, options):
     """
     Get the closest match to some text given a list of options.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 .
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.2.5/en_core_web_md-2.2.5.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'sqlalchemy >=1.3,<4',
         'nltk >=3.4,<4',
         'spacy >=2,<3',
-        'editdistance <1',
         'mathparse <1',
         'cairosvg >=2,<3',
         'discord.py >=1.2.5,<2',

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'nltk >=3.4,<4',
         'spacy >=2,<3',
         'mathparse <1',
+        'scipy >=1,<2',
         'cairosvg >=2,<3',
         'discord.py >=1.2.5,<2',
         'emoji >=0.5,<1',


### PR DESCRIPTION
This is better than using Levenshtein distance since it considers the meaning of the words instead of the way they are written, so synonyms will produce a high similarity even if they are spelled completely differently. This is slower to calculate but still completes within a few seconds.

However, statements still need to contain at least one matching bigram pair to be selected from the database to check. This can be improved separately after merging.

I used `scipy.spatial.KDTree` to find the closest vector instead of looping over each option and calling `doc1.similarity(doc2)`, since this has a much better performance.